### PR TITLE
Add balanced VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,30 +1,27 @@
 {
+    // Python environment
     "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
-    "python.analysis.typeCheckingMode": "strict",
-    "editor.formatOnSave": true,
-    "editor.codeActionsOnSave": {
-        "source.fixAll": "explicit",
-        "source.organizeImports": "explicit"
-    },
-    "[python]": {
-        "editor.defaultFormatter": "ms-python.black-formatter",
-        "editor.formatOnSave": true,
-        "editor.rulers": [100]
-    },
+    "python.analysis.typeCheckingMode": "basic",
+
+    // Testing
     "python.testing.pytestEnabled": true,
     "python.testing.unittestEnabled": false,
-    "python.testing.nosetestsEnabled": false,
+
+    // Editor settings
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter",
+        "editor.rulers": [100]
+    },
+
+    // Code quality
     "python.analysis.autoImportCompletions": true,
-    "python.linting.enabled": true,
-    "python.linting.mypyEnabled": true,
-    "python.linting.mypyCategorySeverity.error": "Error",
     "python.formatting.provider": "black",
     "python.formatting.blackArgs": ["--line-length", "100"],
+
+    // File handling
     "files.exclude": {
         "**/__pycache__": true,
         "**/.pytest_cache": true,
         "**/*.pyc": true
-    },
-    "files.trimTrailingWhitespace": true,
-    "files.insertFinalNewline": true
+    }
 }


### PR DESCRIPTION
This PR adds VS Code settings that:

- Adds support for UV virtual environments
- Maintains essential Python development settings
- Removes overly prescriptive settings
- Keeps useful defaults for Python development
- Updates .gitignore to include .vscode directory